### PR TITLE
Add ruff linter, update import statements and adjust .gitignore

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -435,6 +435,32 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "ruff"
+version = "0.1.5"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.1.5-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:32d47fc69261c21a4c48916f16ca272bf2f273eb635d91c65d5cd548bf1f3d96"},
+    {file = "ruff-0.1.5-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:171276c1df6c07fa0597fb946139ced1c2978f4f0b8254f201281729981f3c17"},
+    {file = "ruff-0.1.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:17ef33cd0bb7316ca65649fc748acc1406dfa4da96a3d0cde6d52f2e866c7b39"},
+    {file = "ruff-0.1.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b2c205827b3f8c13b4a432e9585750b93fd907986fe1aec62b2a02cf4401eee6"},
+    {file = "ruff-0.1.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb408e3a2ad8f6881d0f2e7ad70cddb3ed9f200eb3517a91a245bbe27101d379"},
+    {file = "ruff-0.1.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f20dc5e5905ddb407060ca27267c7174f532375c08076d1a953cf7bb016f5a24"},
+    {file = "ruff-0.1.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aafb9d2b671ed934998e881e2c0f5845a4295e84e719359c71c39a5363cccc91"},
+    {file = "ruff-0.1.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a4894dddb476597a0ba4473d72a23151b8b3b0b5f958f2cf4d3f1c572cdb7af7"},
+    {file = "ruff-0.1.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a00a7ec893f665ed60008c70fe9eeb58d210e6b4d83ec6654a9904871f982a2a"},
+    {file = "ruff-0.1.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a8c11206b47f283cbda399a654fd0178d7a389e631f19f51da15cbe631480c5b"},
+    {file = "ruff-0.1.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fa29e67b3284b9a79b1a85ee66e293a94ac6b7bb068b307a8a373c3d343aa8ec"},
+    {file = "ruff-0.1.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9b97fd6da44d6cceb188147b68db69a5741fbc736465b5cea3928fdac0bc1aeb"},
+    {file = "ruff-0.1.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:721f4b9d3b4161df8dc9f09aa8562e39d14e55a4dbaa451a8e55bdc9590e20f4"},
+    {file = "ruff-0.1.5-py3-none-win32.whl", hash = "sha256:f80c73bba6bc69e4fdc73b3991db0b546ce641bdcd5b07210b8ad6f64c79f1ab"},
+    {file = "ruff-0.1.5-py3-none-win_amd64.whl", hash = "sha256:c21fe20ee7d76206d290a76271c1af7a5096bc4c73ab9383ed2ad35f852a0087"},
+    {file = "ruff-0.1.5-py3-none-win_arm64.whl", hash = "sha256:82bfcb9927e88c1ed50f49ac6c9728dab3ea451212693fe40d08d314663e412f"},
+    {file = "ruff-0.1.5.tar.gz", hash = "sha256:5cbec0ef2ae1748fb194f420fb03fb2c25c3258c86129af7172ff8f198f125ab"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.23"
 description = "Database Abstraction Library"
@@ -563,4 +589,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "29c8d198208a27d9298b4bcff5195c8203171a4025d70ebdc729ce53989f3925"
+content-hash = "05829ecb716bf2cef63eb7305f97728aceca3bbd4e6aaf122c5e13760623a9f0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 name = "flask-template"
 version = "0.1.0"
 description = "Flask project boilerplate"
-authors = ["hrimov <andrew.hrimov@gmail.com>"]
+authors = [
+    "hrimov <andrew.hrimov@gmail.com>",
+    "LazorykV <lazorkinv@gmail.com>"
+]
 license = "MIT"
 readme = "README.md"
 packages = [{ include = "app", from = "src" }]
@@ -13,6 +16,7 @@ flask = "^3.0.0"
 sqlalchemy = "^2.0.23"
 psycopg = "^3.1.12"
 alembic = "^1.12.1"
+ruff = "^0.1.5"
 pydantic = "^2.4.2"
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,56 @@
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "migrations"
+]
+
+line-length = 100
+indent-width = 4
+
+ignore-init-module-imports = true
+
+target-version = "py310"
+
+[lint]
+select = [
+    "B",
+    "E",
+    "F",
+    "ISC",
+    "UP",
+]
+ignore = []
+
+fixable = ["ALL"]
+unfixable = []
+
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[lint.per-file-ignores]
+"__init__.py" = ["E402"]
+"**/{tests,docs,tools}/*" = ["E402"]
+
+[format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/src/app/controllers/base.py
+++ b/src/app/controllers/base.py
@@ -15,6 +15,7 @@ class Controller(Generic[Model]):
         self.model: type[Model] = type(Model)
 
     # some base operations
-    # Note: controller needs to also provide de(serialization), or it can be imported from the separate layer
+    # Note: controller needs to also provide de(serialization),
+    # or it can be imported from the separate layer
     def get(self, pk: int) -> Model:
         return self.session.get(self.model, pk)

--- a/src/app/infrastructure/__init__.py
+++ b/src/app/infrastructure/__init__.py
@@ -1,3 +1,9 @@
 from .config import AppConfig, DatabaseConfig, load_config
-# from .database import *
 from .log import configure_logging
+
+__all__ = [
+    AppConfig,
+    DatabaseConfig,
+    load_config,
+    configure_logging,
+]

--- a/src/app/infrastructure/config/__init__.py
+++ b/src/app/infrastructure/config/__init__.py
@@ -1,2 +1,8 @@
 from .models import AppConfig, DatabaseConfig
 from .parsers import load_config
+
+__all__ = [
+    AppConfig,
+    DatabaseConfig,
+    load_config,
+]

--- a/src/app/infrastructure/log/__init__.py
+++ b/src/app/infrastructure/log/__init__.py
@@ -1,1 +1,5 @@
 from .main import configure_logging
+
+__all__ = [
+    configure_logging,
+]

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -1,2 +1,8 @@
 from .base import BaseModel, CreatedUpdatedAtMixin
 from .user import User
+
+__all__ = [
+    BaseModel,
+    CreatedUpdatedAtMixin,
+    User,
+]


### PR DESCRIPTION
Added 'ruff' linter to the project. This python linter, written in rust, is notably faster and was added to improve code quality checks. The '__all__' declaration was added to several '__init__.py' files to enable precise importing, allowing for more explicit and manageable use of the module's public API in other parts of the code. The '.gitignore' file was updated to ignore ruff's cache directory. Finally, the 'poetry.lock' file was updated, reflecting the new dependencies and versions.